### PR TITLE
Allow a callback to be executed on connection

### DIFF
--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -16,6 +16,11 @@ class ClientOptions
         return $this->options['options']['debug'] ?? false;
     }
 
+    public function getExecutionTimeout(): float
+    {
+        return (float) ($this->options['options']['execution_timeout'] ?? 1.5);
+    }
+
     public function getIdentity(): array
     {
         $default = ['username' => 'justinfan' . random_int(1000, 80000), 'password' => 'SCHMOOPIIE'];


### PR DESCRIPTION
Like we said on Twitter, this PR aims to allow users to execute a callback on connection and then close it. The docs need to be updated as well.

An example:

```php
$client = new Client(new ClientOptions([
	'identity' => [
		'username' => 'ghostzero',
		'password' => 'oauth:...',
	],
	'channels' => ['ghostzero'],
]));

$client->connect(function () use ($client) {
	$client->say('ghostzero', 'Hello');
});

echo "Hello sent!";
```