### PR TITLE
Allow using other implementations of ReactPHP's LoopInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "ext-json": "*"
   },
   "require-dev": {
+    "amphp/react-adapter": "^2.1",
     "phpunit/phpunit": "^9.3.3"
   },
   "minimum-stability": "dev",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,4 +16,7 @@
             <directory suffix=".php">./src</directory>
         </include>
     </coverage>
+    <php>
+        <const name="AMP_REACT_ADAPTER_DISABLE_FACTORY_OVERRIDE" value="true" force="true" />
+    </php>
 </phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,7 +36,7 @@ class Client
     public function __construct(ClientOptions $options)
     {
         $this->options = $options;
-        $this->loop = \React\EventLoop\Factory::create();
+        $this->loop = $options->getLoop();
         $this->ircMessageParser = new IrcMessageParser();
         $this->eventHandler = new EventHandler();
     }

--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -2,6 +2,9 @@
 
 namespace GhostZero\Tmi;
 
+use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
+
 class ClientOptions
 {
     private array $options;
@@ -81,5 +84,10 @@ class ClientOptions
     public function getReconnectDelay(): int
     {
         return $this->options['connection']['reconnect_delay'] ?? 3;
+    }
+
+    public function getLoop(): LoopInterface
+    {
+        return $this->options['loop'] ?? Loop::get();
     }
 }

--- a/tests/Feature/ClientTest.php
+++ b/tests/Feature/ClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Amp\ReactAdapter\ReactAdapter;
 use GhostZero\Tmi\Client;
 use GhostZero\Tmi\ClientOptions;
 use GhostZero\Tmi\Events\Irc\NameReplyEvent;
@@ -22,6 +23,30 @@ class ClientTest extends TestCase
                 'rejoin' => true,
             ],
             'channels' => ['ghostzero']
+        ]));
+
+        $client->on(NameReplyEvent::class, function (NameReplyEvent $event) {
+            $this->assertEquals('#ghostzero', $event->channel);
+            $event->client->close();
+        });
+
+        $client->connect();
+    }
+
+    /**
+     * @medium
+     */
+    public function testClientConnectionWithAlternativeLoop(): void
+    {
+        $client = new Client(new ClientOptions([
+            'options' => ['debug' => true],
+            'connection' => [
+                'secure' => true,
+                'reconnect' => true,
+                'rejoin' => true,
+            ],
+            'channels' => ['ghostzero'],
+            'loop' => ReactAdapter::get(),
         ]));
 
         $client->on(NameReplyEvent::class, function (NameReplyEvent $event) {


### PR DESCRIPTION
I'm using Amp for a project of mine, which uses a different EventLoop implementation.

Luckily enough they provide an adapter for ReactPHP's event loop.

LMK if the `ClientOptions` class is the appropriate place to put the override, or if you'd prefer a second parameter in the Client's constructor. Neither should amount to a BC break.

Looking forward to using TMI 👍 