### PR TITLE
Add return types to array methods in Tags class

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -27,7 +27,7 @@ class Tags implements ArrayAccess
         return new self($result);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->tags[] = $value;
@@ -36,12 +36,12 @@ class Tags implements ArrayAccess
         }
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->tags[$offset]);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->tags[$offset]);
     }


### PR DESCRIPTION
Not having return types for methods implemented in ArrayAccess is deprecated in php 8.1. Adding return types to fix it.